### PR TITLE
Updated WeatherService - forecast endpoint also returns current weather

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -7,11 +7,8 @@ const weatherKey = process.env.WEATHER_API_KEY;
 const zipcode = process.env.ZIPCODE;
 
 const controller = async () => {
-  const curWeather = await WeatherService.getCurrentWeather(
-    zipcode,
-    weatherKey
-  );
-  console.log(curWeather);
+  const weatherRawData = await WeatherService.getForecast(zipcode, weatherKey);
+  console.log(weatherRawData.forecast);
 };
 
 module.exports = controller;

--- a/services/weather.service.js
+++ b/services/weather.service.js
@@ -2,12 +2,13 @@ const axios = require("axios");
 const { WEATHER } = require("./constants");
 
 class WeatherService {
-  static async getCurrentWeather(zipcode, apiKey) {
+  static async getForecast(zipcode, apiKey) {
     const options = {
       method: "get",
-      url: `${WEATHER.BASE_URL}/${WEATHER.CURRENT}?key=${apiKey}&q=${zipcode}`,
+      url: `${WEATHER.BASE_URL}/${WEATHER.FORECAST}?key=${apiKey}&q=${zipcode}&days=1&aqi=no&alerts=no`,
     };
     const data = (await axios.request(options)).data;
+    console.log(data);
     return data;
   }
 }


### PR DESCRIPTION
Originally was going to create two static functions in the WeatherService to get current and forecast weather. Forecast endpoint also returns current weather, so this was redundant. More research is needed next time when exploring API endpoints.